### PR TITLE
Fix nested response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,9 @@ request.get('https://www.github.com');
 //   method: 'GET',
 //   type: 'request',
 //   uri: 'https://www.github.com/' }
-// { id: '6bfc21a0-0dad-48b2-8378-762e5f85f014',
-//   response: {
-//     headers: …,
-//     statusCode: 301 },
+// { headers: …,
+//   id: '6bfc21a0-0dad-48b2-8378-762e5f85f014',
+//   statusCode: 301,
 //   type: 'redirect',
 //   uri: 'https://github.com/' }
 // { headers: …,
@@ -46,10 +45,9 @@ request.get('https://www.github.com');
 //   method: 'GET',
 //   type: 'request',
 //   uri: 'https://github.com/' }
-// { id: '6bfc21a0-0dad-48b2-8378-762e5f85f014',
-//   response:
-//    { headers: …,
-//      statusCode: 200 },
+// { headers: …,
+//   id: '6bfc21a0-0dad-48b2-8378-762e5f85f014',
+//   statusCode: 200,
 //   type: 'response',
 //   uri: 'https://github.com/' }
 ```
@@ -58,7 +56,7 @@ You can optionally define a custom logging function which receives the request o
 
 ```javascript
 const logger = require('@uphold/request-logger');
-const request = logger(require('request'), data => console.log(`${data.id} ${data.type}: ${data.uri}${data.response && data.response.statusCode ? ` (${data.response.statusCode})` : ''} ${(data.response && data.response.body ? `${data.response.body}` : '').length} bytes`));
+const request = logger(require('request'), data => console.log(`${data.id} ${data.type}: ${data.uri}${data.statusCode ? ` (${data.statusCode})` : ''} ${(data.body ? `${data.body}` : '').length} bytes`));
 
 request.get('https://www.github.com', () => {});
 
@@ -74,7 +72,7 @@ Each `data` object contains a `type` property indicating the type of event:
 
 - **request** - the request succeeded. `data.body` may be defined for POST requests.
 
-- **response** - the request returned a response. Note that `request` only buffers the response body if a callback was given, so only in that case will `data.response.body` be defined.
+- **response** - the request returned a response. Note that `request` only buffers the response body if a callback was given, so only in that case will `data.body` be defined.
 
 - **redirect** - the request received a redirect status code (_HTTP 3xx_). `data.uri` will point to the URI of the next request.
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,13 +31,11 @@ module.exports = function logger(request, log) {
         }
 
         log({
+          body: response.body,
           duration: Date.now() - startTime,
+          headers: response.headers,
           id,
-          response: {
-            body: response.body,
-            headers: response.headers,
-            statusCode: response.statusCode
-          },
+          statusCode: response.statusCode,
           type: 'response',
           uri: this.uri.href
         }, this);
@@ -54,11 +52,9 @@ module.exports = function logger(request, log) {
       }).on('redirect', function() {
         log({
           duration: Date.now() - startTime,
+          headers: this.response.headers,
           id,
-          response: {
-            headers: this.response.headers,
-            statusCode: this.response.statusCode
-          },
+          statusCode: this.response.statusCode,
           type: 'redirect',
           uri: this.uri.href
         }, this);
@@ -83,11 +79,9 @@ module.exports = function logger(request, log) {
 
         log({
           duration: Date.now() - startTime,
+          headers: response.headers,
           id,
-          response: {
-            headers: response.headers,
-            statusCode: response.statusCode
-          },
+          statusCode: response.statusCode,
           type: 'response',
           uri: this.uri.href
         }, this);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -96,11 +96,9 @@ describe('request-logger', () => {
     client(url).on('complete', () => {
       expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
         duration: expect.any(Number),
+        headers: {},
         id: log.calls.mostRecent().args[0].id,
-        response: {
-          headers: {},
-          statusCode: 200
-        },
+        statusCode: 200,
         type: 'response',
         uri: 'http://foo.bar/'
       }));
@@ -117,12 +115,10 @@ describe('request-logger', () => {
 
     client(url, () => {}).on('complete', () => {
       expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
+        body: 'foo',
         duration: expect.any(Number),
-        response: {
-          body: 'foo',
-          headers: {},
-          statusCode: 200
-        },
+        headers: {},
+        statusCode: 200,
         type: 'response',
         uri: 'http://foo.bar/'
       }));
@@ -141,12 +137,10 @@ describe('request-logger', () => {
 
     client(url, () => {}).on('complete', () => {
       expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
+        body: 'foo',
         duration: 0,
-        response: {
-          body: 'foo',
-          headers: {},
-          statusCode: 200
-        },
+        headers: {},
+        statusCode: 200,
         type: 'response',
         uri: 'http://foo.bar/'
       }));
@@ -163,12 +157,10 @@ describe('request-logger', () => {
 
     client(url, () => {}).on('complete', () => {
       expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
+        body: 'foo',
         duration: expect.any(Number),
-        response: {
-          body: 'foo',
-          headers: {},
-          statusCode: 200
-        },
+        headers: {},
+        statusCode: 200,
         type: 'response',
         uri: 'http://foo.bar/'
       }));
@@ -211,12 +203,10 @@ describe('request-logger', () => {
     client(url).on('redirect', () => {
       expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
         duration: expect.any(Number),
-        response: {
-          headers: {
-            location: redirectUrl
-          },
-          statusCode: 302
+        headers: {
+          location: redirectUrl
         },
+        statusCode: 302,
         type: 'redirect',
         uri: redirectUrl
       }));
@@ -275,10 +265,8 @@ describe('request-logger', () => {
     client(url).on('response', () => {
       expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
         duration: expect.any(Number),
-        response: {
-          headers: {},
-          statusCode: 200
-        },
+        headers: {},
+        statusCode: 200,
         type: 'response',
         uri: 'http://foo.bar/'
       }));
@@ -296,10 +284,8 @@ describe('request-logger', () => {
     client(url).on('response', () => {
       expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
         duration: expect.any(Number),
-        response: {
-          headers: {},
-          statusCode: 200
-        },
+        headers: {},
+        statusCode: 200,
         type: 'response',
         uri: 'http://foo.bar/'
       }));
@@ -398,11 +384,9 @@ describe('request-logger', () => {
 
         client[verb](url).on('complete', () => {
           expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
+            headers: {},
             id: expect.any(String),
-            response: {
-              headers: {},
-              statusCode: 200
-            },
+            statusCode: 200,
             type: 'response',
             uri: 'http://foo.bar/'
           }));
@@ -419,13 +403,11 @@ describe('request-logger', () => {
 
         client[verb](url, () => {}).on('complete', () => {
           expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
+            body: 'foo',
             duration: expect.any(Number),
+            headers: {},
             id: expect.any(String),
-            response: {
-              body: 'foo',
-              headers: {},
-              statusCode: 200
-            },
+            statusCode: 200,
             type: 'response',
             uri: 'http://foo.bar/'
           }));
@@ -465,13 +447,11 @@ describe('request-logger', () => {
           client[verb](url).on('redirect', () => {
             expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
               duration: expect.any(Number),
-              id: expect.any(String),
-              response: {
-                headers: {
-                  location: redirectUrl
-                },
-                statusCode: 302
+              headers: {
+                location: redirectUrl
               },
+              id: expect.any(String),
+              statusCode: 302,
               type: 'redirect',
               uri: redirectUrl
             }));
@@ -535,11 +515,9 @@ describe('request-logger', () => {
         client[verb](url).on('response', () => {
           expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
             duration: expect.any(Number),
+            headers: {},
             id: expect.any(String),
-            response: {
-              headers: {},
-              statusCode: 200
-            },
+            statusCode: 200,
             type: 'response',
             uri: 'http://foo.bar/'
           }));


### PR DESCRIPTION
This PR changes the `response` object to be at the root level, much like the request properties.

The reasoning is that we already have a `type={request, response, redirect, etc.}` to indicate the type of object and, therefore, there is no need to further nest the response properties.