### PR TITLE
Remove `lodash.clonedeep`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "version": "npm run changelog --future-release=$npm_package_version && git add -A CHANGELOG.md"
   },
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@
  */
 
 const Proxy = require('./proxy');
-const clone = require('lodash.clonedeep');
 const uuid = require('uuid/v4');
 
 /**
@@ -36,7 +35,7 @@ module.exports = function logger(request, log) {
           id,
           response: {
             body: response.body,
-            headers: clone(response.headers),
+            headers: response.headers,
             statusCode: response.statusCode
           },
           type: 'response',
@@ -46,7 +45,7 @@ module.exports = function logger(request, log) {
         log({
           duration: Date.now() - startTime,
           error,
-          headers: clone(this.headers),
+          headers: this.headers,
           id,
           method: this.method.toUpperCase(),
           type: 'error',
@@ -57,7 +56,7 @@ module.exports = function logger(request, log) {
           duration: Date.now() - startTime,
           id,
           response: {
-            headers: clone(this.response.headers),
+            headers: this.response.headers,
             statusCode: this.response.statusCode
           },
           type: 'redirect',
@@ -65,7 +64,7 @@ module.exports = function logger(request, log) {
         }, this);
       }).on('request', function() {
         const data = {
-          headers: clone(this.headers),
+          headers: this.headers,
           id,
           method: this.method,
           type: 'request',
@@ -86,7 +85,7 @@ module.exports = function logger(request, log) {
           duration: Date.now() - startTime,
           id,
           response: {
-            headers: clone(response.headers),
+            headers: response.headers,
             statusCode: response.statusCode
           },
           type: 'response',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,9 +51,7 @@ describe('request-logger', () => {
     client(url).on('response', () => {
       expect(console.error).toHaveBeenCalled();
       expect(console.error.calls.first().args[0]).toMatchObject({
-        headers: {
-          host: 'foo.bar'
-        },
+        headers: {},
         method: 'GET',
         type: 'request',
         uri: 'http://foo.bar/'
@@ -235,9 +233,7 @@ describe('request-logger', () => {
 
     client(url).on('request', () => {
       expect(log.calls.mostRecent().args[0]).toMatchObject({
-        headers: {
-          host: 'foo.bar'
-        },
+        headers: {},
         id: log.calls.mostRecent().args[0].id,
         method: 'GET',
         type: 'request',
@@ -258,8 +254,7 @@ describe('request-logger', () => {
       expect(log.calls.mostRecent().args[0]).toMatchObject({
         body: 'foo',
         headers: {
-          'content-length': 3,
-          host: 'foo.bar'
+          'content-length': 3
         },
         id: log.calls.mostRecent().args[0].id,
         method: 'GET',
@@ -321,9 +316,7 @@ describe('request-logger', () => {
 
     client(url, () => {}).on('response', () => {
       expect(log.calls.mostRecent().args[0]).toEqual(expect.objectContaining({
-        headers: {
-          host: 'foo.bar'
-        },
+        headers: {},
         method: 'GET',
         type: 'request',
         uri: 'http://foo.bar/'
@@ -496,9 +489,7 @@ describe('request-logger', () => {
 
         client[verb](url).on('request', () => {
           expect(log.calls.mostRecent().args[0]).toMatchObject({
-            headers: {
-              host: 'foo.bar'
-            },
+            headers: {},
             type: 'request',
             uri: 'http://foo.bar/'
           });
@@ -521,8 +512,7 @@ describe('request-logger', () => {
             expect(log.calls.mostRecent().args[0]).toMatchObject({
               body: 'foo',
               headers: {
-                'content-length': 3,
-                host: 'foo.bar'
+                'content-length': 3
               },
               type: 'request',
               uri: 'http://foo.bar/'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,10 +1680,6 @@ lodash.clonedeep@^3.0.0:
     lodash._baseclone "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"


### PR DESCRIPTION
This PR removes `lodash.clonedeep` and the header cloning functionality which seemed a bit arbitrary.

Only the headers were being cloned (why not the `body`?) and ultimately it is cpu-time that is being spent on something that _dependees_ may already be doing.